### PR TITLE
Fix saving image fails if the image path includes whitespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.1
+* Fix saving image fails if the image path includes whitespaces [#2](https://github.com/ellet0/gal-linux/issues/2)
+
 ## 0.1.0
 * Fix old links
 * Update minimum version of `gal`

--- a/lib/src/gal_linux_impl.dart
+++ b/lib/src/gal_linux_impl.dart
@@ -69,7 +69,7 @@ final class GalLinuxImpl {
         final templLocation =
             _getNewTempFileLocation(fileName: path.basename(filePath));
         await executeCommand(
-          executalbe: 'wget',
+          executable: 'wget',
           args: ['-O', templLocation, filePath],
         );
         filePath = templLocation;
@@ -85,7 +85,7 @@ final class GalLinuxImpl {
         );
         await _makeSureParentFolderExists(path: newFileLocation);
         await executeCommand(
-          executalbe: 'mv',
+          executable: 'mv',
           args: [filePath, newFileLocation],
         );
       } else {
@@ -94,14 +94,14 @@ final class GalLinuxImpl {
             _getNewTempFileLocation(fileName: path.basename(filePath));
         await _makeSureParentFolderExists(path: newFileLocation);
         executeCommand(
-          executalbe: 'mv',
+          executable: 'mv',
           args: [filePath, newFileLocation],
         );
       }
       // Remove the downloaded temp file from the network if it exists
       if (downloadedFromNetwork) {
         await executeCommand(
-          executalbe: 'rm',
+          executable: 'rm',
           args: [filePath],
         );
       }
@@ -166,7 +166,7 @@ final class GalLinuxImpl {
   static Future<void> _makeSureParentFolderExists(
       {required String path}) async {
     await executeCommand(
-      executalbe: 'mkdir',
+      executable: 'mkdir',
       args: ['-p', File(path).parent.path],
     );
   }
@@ -199,7 +199,7 @@ final class GalLinuxImpl {
   }
 
   static Future<void> open() async => executeCommand(
-        executalbe: 'xdg-open',
+        executable: 'xdg-open',
         args: ['${_getHomeDirectory()}/Pictures'],
       );
 

--- a/lib/src/utils/command_line.dart
+++ b/lib/src/utils/command_line.dart
@@ -3,14 +3,14 @@ import 'dart:io' show ProcessException, Process;
 import 'package:flutter/foundation.dart' show kDebugMode, kIsWeb;
 
 Future<String> executeCommand({
-  required String executalbe,
+  required String executable,
   required List<String> args,
   bool printResult = true,
   String? workingDirectory,
 }) async {
   if (kDebugMode) {
     if (printResult) {
-      print('$executalbe ${args.join(' ')}');
+      print('$executable ${args.join(' ')}');
     }
   }
   if (kIsWeb) {
@@ -19,7 +19,7 @@ Future<String> executeCommand({
     );
   }
   final command = await Process.run(
-    executalbe,
+    executable,
     args,
     workingDirectory: workingDirectory,
   );
@@ -32,7 +32,7 @@ Future<String> executeCommand({
       }
     }
     throw ProcessException(
-      executalbe,
+      executable,
       args,
       command.stderr,
       command.exitCode,

--- a/lib/src/utils/command_line.dart
+++ b/lib/src/utils/command_line.dart
@@ -2,15 +2,12 @@ import 'dart:io' show ProcessException, Process;
 
 import 'package:flutter/foundation.dart' show kDebugMode, kIsWeb;
 
-Future<String> executeCommand(
-  String value, {
+Future<String> executeCommand({
+  required String executalbe,
+  required List<String> args,
   bool printResult = true,
   String? workingDirectory,
 }) async {
-  final executalbe = value.split(' ')[0];
-  final args = value.split(' ')
-    ..removeAt(0)
-    ..toList();
   if (kDebugMode) {
     if (printResult) {
       print('$executalbe ${args.join(' ')}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gal_linux
 description: Flutter Plugin for Saving Image/Video to the Photo Gallery | How to Save Image/Video to the Photo Gallery in Flutter
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/ellet0/gal-linux/
 repository: https://github.com/ellet0/gal-linux/
 issue_tracker: https://github.com/ellet0/gal-linux/issues/


### PR DESCRIPTION
- An attempt to fix #2 


The fix by refactoring/reverting the way we execute commands to what it was in the first place/same as dart
by requiring both the `executable` and the `args` as `List<String>`